### PR TITLE
--mixins CRUD option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,19 +35,21 @@ Installation and usage
 ----------------------
 
 For a detailed guide read `scaffold django apis like a champion <https://www.abdenasser.com/scaffold-django-apis>`_
-
+**********************
 
 This library assumes that you have setup your project with **Django Rest
 Framework**.
 if not, please refer to `this guide <https://www.django-rest-framework.org/#installation>`_
 
-Install dr_scaffold package :
+1- Install dr_scaffold package :
+================================
 
 .. code:: console
 
     $ pip install dr-scaffold
 
-Add ``dr_scaffold`` to your INSTALLED\_APPS like this:
+2- Add ``dr_scaffold`` to your INSTALLED\_APPS like this:
+=========================================================
 
 .. code:: python
 
@@ -56,8 +58,8 @@ Add ``dr_scaffold`` to your INSTALLED\_APPS like this:
         'dr_scaffold'
     ]
 
-If you are using a custom API structure, add ``CORE_FOLDER`` and ``API_FOLDER`` to your ``settings.py``:
-
+3- If you are using a custom API structure, add ``CORE_FOLDER`` and ``API_FOLDER`` to your ``settings.py``:
+===========================================================================================================
 
 .. code:: python
     
@@ -66,20 +68,89 @@ If you are using a custom API structure, add ``CORE_FOLDER`` and ``API_FOLDER`` 
     CORE_FOLDER = "my_core_folder/" # you can leave them empty
     API_FOLDER = "my_api_folder/"   # or set them to be the same
 
+4- Run the your scaffolds like this:
+===========================================
 
-Enjoy 🎉
+.. code:: console
+
+    $ python manage.py dr_scaffold blog Post body:textfield author:foreignkey:Author --mixins CRUD
+
+    🎉 Your RESTful Post api resource is ready 🎉
+
 
 .. raw:: html
    </br></br>
 
+Supported ViewSet types
+---------------------
+
+We support two types of ViewSets, we support **ModelViewSet** and we support **ViewSets** with Mixins. 
+
+- ModelViewSets are the default that get generated with the dr_scaffold command
+- To generate a view with Mixins pass a value of what mixins you want to include like ``--mixins CRUD`` this will result in a view with the Create, List, Retrieve, Update, Destroy actions.
+
+Let's generate an API that does only support the **Create** and **Read** methods (Read is both list and retrieve):
+
+.. code:: console
+
+    $ python manage.py dr_scaffold blog Author name:charfield --mixins CR
+    
+    🎉 Your RESTful Post api resource is ready 🎉
+
+
+The command will generate an Author API with a ViewSet like the following:
+
+.. code:: python
+
+    class AuthorViewSet(
+        mixins.CreateModelMixin,
+        mixins.ListModelMixin,
+        mixins.RetrieveModelMixin,
+        viewsets.GenericViewSet
+    ):
+        queryset = Author.objects.all()
+        serializer_class = AuthorSerializer
+        #permission_classes = (permissions.IsAuthenticated,)
+
+        def get_queryset(self):
+            #user = self.request.user
+            queryset = Author.objects.all()
+            #insert specific queryset logic here
+            return queryset
+
+        def get_object(self):
+            #insert specific get_object logic here
+            return super().get_object()
+
+        def create(self, request, *args, **kwargs):
+            serializer = AuthorSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            return Response(serializer.data)
+
+        def list(self, request, *args, **kwargs):
+            queryset = self.get_queryset()
+            serializer = AuthorSerializer(queryset, many=True)
+            return Response(serializer.data)
+
+        def retrieve(self, request, *args, **kwargs):
+            instance = self.get_object()
+            serializer = AuthorSerializer(instance=instance)
+            return Response(serializer.data)
+
+.. raw:: html
+   </br></br>
+   
 Supported field types
 ---------------------
 
 We support most of django field types.
 
+.. raw:: html
+   </br></br>
+
 TODO
 ----
 
 -  add an option to include swagger documentation
--  handle DRF ViewSets using Mixins
 

--- a/dr_scaffold/generators.py
+++ b/dr_scaffold/generators.py
@@ -290,6 +290,9 @@ class ViewGenerator(BaseGenerator):
     """
 
     def get_mixins_template(self):
+        """
+        returns viewset template matching the mixins based on developer command
+        """
         mixins_list = {key: view_templates.CLRUD_MIXINS[key] for key in self.mixins}
         mixins_string = "".join(
             str(mixins_list[x] % {"model": self.model_name}) for x in mixins_list

--- a/dr_scaffold/generators.py
+++ b/dr_scaffold/generators.py
@@ -84,13 +84,13 @@ class AppGenerator(BaseGenerator):
         """
         Returns all import statements
         """
-        VIEW_SETUP = "FULL_SETUP" if self.is_full else "SETUP"
+        view_setup_key = "FULL_SETUP" if self.is_full else "SETUP"
         return (
             serializer_templates.SETUP,
             url_templates.SETUP,
             model_templates.SETUP,
             admin_templates.SETUP,
-            getattr(view_templates, VIEW_SETUP),
+            getattr(view_templates, view_setup_key),
             app_template.TEMPLATE
             % (
                 self.app_name.capitalize(),
@@ -262,8 +262,8 @@ class SerializerGenerator(BaseGenerator):
         """
         app_dir = self.core_app_path
         app_path = app_dir.replace("/", ".")
-        SERIALIZER = "FULL_SERIALIZER" if self.is_full else "SERIALIZER"
-        serializer_template = getattr(serializer_templates, SERIALIZER) % {
+        serializer_key = "FULL_SERIALIZER" if self.is_full else "SERIALIZER"
+        serializer_template = getattr(serializer_templates, serializer_key) % {
             "model": self.model_name
         }
         imports = serializer_templates.MODEL_IMPORT % {
@@ -297,8 +297,10 @@ class ViewGenerator(BaseGenerator):
         """
         core_app_path = self.core_app_path.replace("/", ".")
         api_app_path = self.api_app_path.replace("/", ".")
-        VIEWSET = "FULL_VIEWSET" if self.is_full else "VIEWSET"
-        viewset_template = getattr(view_templates, VIEWSET) % {"model": self.model_name}
+        viewset_key = "FULL_VIEWSET" if self.is_full else "VIEWSET"
+        viewset_template = getattr(view_templates, viewset_key) % {
+            "model": self.model_name
+        }
         model_import_template = view_templates.MODEL_IMPORT % {
             "app": core_app_path,
             "model": self.model_name,

--- a/dr_scaffold/generators.py
+++ b/dr_scaffold/generators.py
@@ -84,13 +84,12 @@ class AppGenerator(BaseGenerator):
         """
         Returns all import statements
         """
-        view_setup_key = "FULL_SETUP" if self.is_full else "SETUP"
         return (
             serializer_templates.SETUP,
             url_templates.SETUP,
             model_templates.SETUP,
             admin_templates.SETUP,
-            getattr(view_templates, view_setup_key),
+            view_templates.SETUP,
             app_template.TEMPLATE
             % (
                 self.app_name.capitalize(),

--- a/dr_scaffold/management/commands/dr_scaffold.py
+++ b/dr_scaffold/management/commands/dr_scaffold.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             "--mixins",
             nargs="?",
             default="None",
-            help="ex. --mixins CLRUD where CLRUD are letters of your viewset actions",
+            help="ex. --mixins CRUD where CRUD are letters of your viewset actions",
         )
 
     def handle(self, *args, **kwargs):

--- a/dr_scaffold/management/commands/dr_scaffold.py
+++ b/dr_scaffold/management/commands/dr_scaffold.py
@@ -29,14 +29,10 @@ class Command(BaseCommand):
              ModelName fields).""",
         )
         # Named (optional) arguments
-        parser.add_argument(
-            "--fullset",
-            action="store_true",
-            help="Delete poll instead of closing it",
-        )
+        parser.add_argument("-f", "--fullset", const="fullset", action="store_const")
 
     def handle(self, *args, **kwargs):
         # handle the creation of an app with default files first
-        is_full_viewset = hasattr(kwargs, "fullset")
+        is_full_viewset = kwargs["fullset"] == "fullset"
         generator = Generator(args[0], args[1], args[2:], is_full_viewset)
         generator.run()

--- a/dr_scaffold/management/commands/dr_scaffold.py
+++ b/dr_scaffold/management/commands/dr_scaffold.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
      to use REST api"""
     missing_args_message = (
         "You are missing some arguments in your command check the example below"
-        "python manage.py dr_scaffold apps_folder/blog Article title:char body:text"
+        "python manage.py dr_scaffold blog Article title:char body:text"
     )
 
     def add_arguments(self, parser):

--- a/dr_scaffold/management/commands/dr_scaffold.py
+++ b/dr_scaffold/management/commands/dr_scaffold.py
@@ -28,8 +28,15 @@ class Command(BaseCommand):
             help="""Scaffold arguments (app_name
              ModelName fields).""",
         )
+        # Named (optional) arguments
+        parser.add_argument(
+            "--fullset",
+            action="store_true",
+            help="Delete poll instead of closing it",
+        )
 
     def handle(self, *args, **kwargs):
         # handle the creation of an app with default files first
-        generator = Generator(args[0], args[1], args[2:])
+        is_full_viewset = hasattr(kwargs, "fullset")
+        generator = Generator(args[0], args[1], args[2:], is_full_viewset)
         generator.run()

--- a/dr_scaffold/management/commands/dr_scaffold.py
+++ b/dr_scaffold/management/commands/dr_scaffold.py
@@ -29,10 +29,18 @@ class Command(BaseCommand):
              ModelName fields).""",
         )
         # Named (optional) arguments
-        parser.add_argument("-f", "--fullset", const="fullset", action="store_const")
+        parser.add_argument(
+            "--mixins",
+            nargs="?",
+            default="None",
+            help="ex. --mixins CLRUD where the CLRUD are the first letters of actions you want in your viewset",
+        )
 
     def handle(self, *args, **kwargs):
         # handle the creation of an app with default files first
-        is_full_viewset = kwargs["fullset"] == "fullset"
-        generator = Generator(args[0], args[1], args[2:], is_full_viewset)
+        actions = []
+        actions[:0] = kwargs["mixins"]
+        if kwargs["mixins"] == "None":
+            actions = False
+        generator = Generator(args[0], args[1], args[2:], actions)
         generator.run()

--- a/dr_scaffold/management/commands/dr_scaffold.py
+++ b/dr_scaffold/management/commands/dr_scaffold.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             "--mixins",
             nargs="?",
             default="None",
-            help="ex. --mixins CLRUD where the CLRUD are the first letters of actions you want in your viewset",
+            help="ex. --mixins CLRUD where CLRUD are letters of your viewset actions",
         )
 
     def handle(self, *args, **kwargs):

--- a/dr_scaffold/scaffold_templates/serializer_templates.py
+++ b/dr_scaffold/scaffold_templates/serializer_templates.py
@@ -2,15 +2,7 @@
 templates for serializers
 """
 
-SERIALIZER = """class %(model)sSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = %(model)s
-        fields = '__all__'
-        
-
-"""
-
-FULL_SERIALIZER = """class %(model)sSerializer(serializers.ModelSerializer):
+SERIALIZER = """class %(model)sSerializer(serializers.ModelSerializer):
     class Meta:
         model = %(model)s
         fields = '__all__'

--- a/dr_scaffold/scaffold_templates/serializer_templates.py
+++ b/dr_scaffold/scaffold_templates/serializer_templates.py
@@ -10,6 +10,14 @@ SERIALIZER = """class %(model)sSerializer(serializers.HyperlinkedModelSerializer
 
 """
 
+FULL_SERIALIZER = """class %(model)sSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = %(model)s
+        fields = '__all__'
+        
+
+"""
+
 MODEL_IMPORT = """from %(app)s.models import %(model)s
 """
 

--- a/dr_scaffold/scaffold_templates/view_templates.py
+++ b/dr_scaffold/scaffold_templates/view_templates.py
@@ -23,8 +23,7 @@ from rest_framework.response import Response
 
 CLRUD_MIXINS = {
     "C": """    mixins.CreateModelMixin,\n""",
-    "L": """    mixins.ListModelMixin,\n""",
-    "R": """    mixins.RetrieveModelMixin,\n""",
+    "R": """    mixins.ListModelMixin,\n    mixins.RetrieveModelMixin,\n""",
     "U": """    mixins.UpdateModelMixin,\n""",
     "D": """    mixins.DestroyModelMixin,\n""",
 }
@@ -35,11 +34,10 @@ CLRUD_ACTIONS = {
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)\n\n""",
-    "L": """    def list(self, request, *args, **kwargs):
+    "R": """    def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         serializer = %(model)sSerializer(queryset, many=True)
-        return Response(serializer.data)\n\n""",
-    "R": """    def retrieve(self, request, *args, **kwargs):
+        return Response(serializer.data)\n\n    def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer = %(model)sSerializer(instance=instance)
         return Response(serializer.data)\n\n""",

--- a/dr_scaffold/scaffold_templates/view_templates.py
+++ b/dr_scaffold/scaffold_templates/view_templates.py
@@ -16,7 +16,7 @@ FULL_VIEWSET = """class %(model)sViewSet(
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     mixins.DestroyModelMixin,
-    GenericViewSet
+    viewsets.GenericViewSet
 ):
     queryset = %(model)s.objects.all()
     serializer_class = %(model)sSerializer
@@ -67,12 +67,7 @@ MODEL_IMPORT = """from %(app)s.models import %(model)s
 SERIALIZER_IMPORT = """from %(app)s.serializers import %(model)sSerializer
 """
 
-SETUP = """from rest_framework import viewsets
-
-"""
-
-FULL_SETUP = """from rest_framework import mixins, permissions
+SETUP = """from rest_framework import mixins, permissions, viewsets
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
 
 """

--- a/dr_scaffold/scaffold_templates/view_templates.py
+++ b/dr_scaffold/scaffold_templates/view_templates.py
@@ -5,7 +5,59 @@ templates for views
 VIEWSET = """class %(model)sViewSet(viewsets.ModelViewSet):
     queryset = %(model)s.objects.all()
     serializer_class = %(model)sSerializer
-    
+
+
+"""
+
+
+FULL_VIEWSET = """class %(model)sViewSet(
+    mixins.CreateModelMixin,
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    GenericViewSet
+):
+    queryset = %(model)s.objects.all()
+    serializer_class = %(model)sSerializer
+    #permission_classes = (permissions.IsAuthenticated,)
+
+    def get_queryset(self):
+        #user = self.request.user
+        queryset = %(model)s.objects.all()
+        #insert specific queryset logic here
+        return queryset
+
+    def get_object(self):
+        #insert specific get_object logic here
+        return super().get_object()
+
+    def create(self, request, *args, **kwargs):
+        serializer = %(model)sSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        serializer = %(model)sSerializer(queryset, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = %(model)sSerializer(instance=instance)
+        return Response(serializer.data)
+
+    def update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = %(model)sSerializer(instance=instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request=request, *args, **kwargs)
+
 
 """
 
@@ -16,5 +68,11 @@ SERIALIZER_IMPORT = """from %(app)s.serializers import %(model)sSerializer
 """
 
 SETUP = """from rest_framework import viewsets
+
+"""
+
+FULL_SETUP = """from rest_framework import mixins, permissions
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
 
 """

--- a/dr_scaffold/scaffold_templates/view_templates.py
+++ b/dr_scaffold/scaffold_templates/view_templates.py
@@ -34,33 +34,23 @@ CLRUD_ACTIONS = {
         serializer = %(model)sSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response(serializer.data)
-
-""",
+        return Response(serializer.data)\n\n""",
     "L": """    def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         serializer = %(model)sSerializer(queryset, many=True)
-        return Response(serializer.data)
-
-""",
+        return Response(serializer.data)\n\n""",
     "R": """    def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer = %(model)sSerializer(instance=instance)
-        return Response(serializer.data)
-
-""",
+        return Response(serializer.data)\n\n""",
     "U": """    def update(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer = %(model)sSerializer(instance=instance, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response(serializer.data)
-
-""",
+        return Response(serializer.data)\n\n""",
     "D": """    def destroy(self, request, *args, **kwargs):
-        return super().destroy(request=request, *args, **kwargs)
-
-""",
+        return super().destroy(request=request, *args, **kwargs)\n\n""",
 }
 
 CLRUD_VIEWSET = """class %(model)sViewSet(

--- a/dr_scaffold/scaffold_templates/view_templates.py
+++ b/dr_scaffold/scaffold_templates/view_templates.py
@@ -9,14 +9,62 @@ VIEWSET = """class %(model)sViewSet(viewsets.ModelViewSet):
 
 """
 
+MODEL_IMPORT = """from %(app)s.models import %(model)s
+"""
 
-FULL_VIEWSET = """class %(model)sViewSet(
-    mixins.CreateModelMixin,
-    mixins.ListModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
-    viewsets.GenericViewSet
+SERIALIZER_IMPORT = """from %(app)s.serializers import %(model)sSerializer
+"""
+
+SETUP = """from rest_framework import mixins, permissions, viewsets
+from rest_framework.response import Response
+
+"""
+
+
+CLRUD_MIXINS = {
+    "C": """    mixins.CreateModelMixin,\n""",
+    "L": """    mixins.ListModelMixin,\n""",
+    "R": """    mixins.RetrieveModelMixin,\n""",
+    "U": """    mixins.UpdateModelMixin,\n""",
+    "D": """    mixins.DestroyModelMixin,\n""",
+}
+
+CLRUD_ACTIONS = {
+    "C": """    def create(self, request, *args, **kwargs):
+        serializer = %(model)sSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+""",
+    "L": """    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        serializer = %(model)sSerializer(queryset, many=True)
+        return Response(serializer.data)
+
+""",
+    "R": """    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = %(model)sSerializer(instance=instance)
+        return Response(serializer.data)
+
+""",
+    "U": """    def update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = %(model)sSerializer(instance=instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+""",
+    "D": """    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request=request, *args, **kwargs)
+
+""",
+}
+
+CLRUD_VIEWSET = """class %(model)sViewSet(
+%(mixins)s\tviewsets.GenericViewSet
 ):
     queryset = %(model)s.objects.all()
     serializer_class = %(model)sSerializer
@@ -32,42 +80,5 @@ FULL_VIEWSET = """class %(model)sViewSet(
         #insert specific get_object logic here
         return super().get_object()
 
-    def create(self, request, *args, **kwargs):
-        serializer = %(model)sSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-        return Response(serializer.data)
-
-    def list(self, request, *args, **kwargs):
-        queryset = self.get_queryset()
-        serializer = %(model)sSerializer(queryset, many=True)
-        return Response(serializer.data)
-
-    def retrieve(self, request, *args, **kwargs):
-        instance = self.get_object()
-        serializer = %(model)sSerializer(instance=instance)
-        return Response(serializer.data)
-
-    def update(self, request, *args, **kwargs):
-        instance = self.get_object()
-        serializer = %(model)sSerializer(instance=instance, data=request.data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-        return Response(serializer.data)
-
-    def destroy(self, request, *args, **kwargs):
-        return super().destroy(request=request, *args, **kwargs)
-
-
-"""
-
-MODEL_IMPORT = """from %(app)s.models import %(model)s
-"""
-
-SERIALIZER_IMPORT = """from %(app)s.serializers import %(model)sSerializer
-"""
-
-SETUP = """from rest_framework import mixins, permissions, viewsets
-from rest_framework.response import Response
-
+%(actions)s
 """

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -27,7 +27,7 @@ class CommandTestCase(SimpleTestCase):
         """
         Test for successful command call
         """
-        call_command("dr_scaffold", "blog", "Article", "title:charfield")
+        call_command("dr_scaffold", "blog", "Article", "title:charfield", False)
         mock_run.assert_called()
 
     @classmethod
@@ -36,5 +36,5 @@ class CommandTestCase(SimpleTestCase):
         """
         Test for successful command call
         """
-        call_command("dr_scaffold", "blog", "Article", "title:charfield")
+        call_command("dr_scaffold", "blog", "Article", "title:charfield", False)
         mock_generate_api.assert_called()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -328,6 +328,27 @@ class TestGenerator(TestCase):
         assert body.count("import ArticleSerializer") == 1
         assert body.count("serializer_class = ArticleSerializer") == 1
 
+    def test_generate_views_with_mixins(self):
+        """
+        Tests
+        """
+        generator_obj = ViewGenerator(
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            mixins=["C", "R"],
+        )
+        generator_obj.core_dir = self.core_folder
+        generator_obj.api_dir = self.api_folder
+        generator_obj.generate_views()
+        with open(f"{self.api_folder}blog/views.py", "r+", encoding="utf8") as file:
+            body = "".join(file.readlines())
+        assert ("import Article" in body) is True
+        assert ("ArticleViewSet" in body) is True
+        assert ("def create" in body) is True
+        assert ("def retrieve" in body) is True
+        assert ("def update" in body) is not True
+
     def test_get_serializer_parts(self):
         """
         Tests

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -84,7 +84,7 @@ class TestGenerator(TestCase):
         """
         Test arguments
         """
-        generator_obj = Generator("blog", "Article", "", True)
+        generator_obj = Generator("blog", "Article", "", False)
         assert generator_obj.app_name == "blog"
         assert generator_obj.model_name == "Article"
 
@@ -93,7 +93,7 @@ class TestGenerator(TestCase):
         Tests imports
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield"), True
+            "blog", "Article", ("title:charfield", "body:textfield"), False
         )
         generator_obj.core_folder = self.core_folder
         files = (f"{self.core_folder}blog/models.py",)
@@ -112,7 +112,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield", "body:textfield"),
-            is_full=True,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -143,7 +143,7 @@ class TestGenerator(TestCase):
         assert fields_string == string
         # test relation field type
         generator_obj2 = Generator(
-            "blog", "Article", ("author:foreignkey:Author",), True
+            "blog", "Article", ("author:foreignkey:Author",), False
         )
         generator_obj2.get_fields_string()
         mock_is_in_file.assert_called_once()
@@ -153,7 +153,7 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj2 = Generator(
-            "blog", "Article", ("author:foreignkey:Author",), True
+            "blog", "Article", ("author:foreignkey:Author",), False
         )
         generator_obj2.core_dir = self.core_folder
         generator_obj2.api_dir = self.api_folder
@@ -200,7 +200,7 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield"), True
+            "blog", "Article", ("title:charfield", "body:textfield"), False
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -215,7 +215,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield", "body:textfield"),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -231,7 +231,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield", "body:textfield"),
-            is_full=True,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -243,7 +243,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Article", ("title:charfield",), True)
+        generator_obj = Generator("blog", "Article", ("title:charfield",), ["C", "R"])
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         head, body = generator_obj.get_admin_parts()
@@ -258,7 +258,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -272,7 +272,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -286,7 +286,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Article", ("title:charfield",), True)
+        generator_obj = Generator("blog", "Article", ("title:charfield",), False)
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         head, body = generator_obj.get_viewset_parts()
@@ -301,7 +301,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=True,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -316,7 +316,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=True,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -336,7 +336,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -352,7 +352,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=True,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -368,7 +368,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -388,7 +388,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -405,7 +405,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -419,7 +419,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -433,7 +433,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Author",
             fields=("name:charfield",),
-            is_full=False,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -459,7 +459,7 @@ class TestGenerator(TestCase):
             app_name="blog2",
             model_name="Article",
             fields=("title:charfield",),
-            is_full=True,
+            mixins=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -479,7 +479,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Author", ("name:charfield",), True)
+        generator_obj = Generator("blog", "Author", ("name:charfield",), False)
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         generator_obj.generate()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -84,7 +84,7 @@ class TestGenerator(TestCase):
         """
         Test arguments
         """
-        generator_obj = Generator("blog", "Article", "")
+        generator_obj = Generator("blog", "Article", "", True)
         assert generator_obj.app_name == "blog"
         assert generator_obj.model_name == "Article"
 
@@ -93,7 +93,7 @@ class TestGenerator(TestCase):
         Tests imports
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield")
+            "blog", "Article", ("title:charfield", "body:textfield"), True
         )
         generator_obj.core_folder = self.core_folder
         files = (f"{self.core_folder}blog/models.py",)
@@ -112,6 +112,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield", "body:textfield"),
+            is_full=True,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -133,7 +134,7 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield")
+            "blog", "Article", ("title:charfield", "body:textfield"), False
         )
         fields_string = generator_obj.get_fields_string()
         body_template = model_templates.TEXTFIELD % dict(name="body")
@@ -141,7 +142,9 @@ class TestGenerator(TestCase):
         string = title_template + body_template
         assert fields_string == string
         # test relation field type
-        generator_obj2 = Generator("blog", "Article", ("author:foreignkey:Author",))
+        generator_obj2 = Generator(
+            "blog", "Article", ("author:foreignkey:Author",), True
+        )
         generator_obj2.get_fields_string()
         mock_is_in_file.assert_called_once()
 
@@ -149,7 +152,9 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj2 = Generator("blog", "Article", ("author:foreignkey:Author",))
+        generator_obj2 = Generator(
+            "blog", "Article", ("author:foreignkey:Author",), True
+        )
         generator_obj2.core_dir = self.core_folder
         generator_obj2.api_dir = self.api_folder
         captured_output = io.StringIO()
@@ -164,7 +169,7 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield")
+            "blog", "Article", ("title:charfield", "body:textfield"), False
         )
         fields_string = generator_obj.get_fields_string()
         model_string = generator_obj.get_model_string()
@@ -176,14 +181,14 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield")
+            "blog", "Article", ("title:charfield", "body:textfield"), False
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         result = generator_obj.run()
         assert result == print("🎉 Your RESTful Article api resource is ready 🎉")
         # test case where something is wrong
-        generator_obj2 = Generator("blog", "Author", ("title:charfiel",))
+        generator_obj2 = Generator("blog", "Author", ("title:charfiel",), False)
         generator_obj2.core_dir = self.core_folder
         generator_obj2.api_dir = self.api_folder
         result = generator_obj2.run()
@@ -195,7 +200,7 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = Generator(
-            "blog", "Article", ("title:charfield", "body:textfield")
+            "blog", "Article", ("title:charfield", "body:textfield"), True
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -210,6 +215,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield", "body:textfield"),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -225,6 +231,7 @@ class TestGenerator(TestCase):
             app_name="blog",
             model_name="Article",
             fields=("title:charfield", "body:textfield"),
+            is_full=True,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -236,7 +243,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Article", ("title:charfield",))
+        generator_obj = Generator("blog", "Article", ("title:charfield",), True)
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         head, body = generator_obj.get_admin_parts()
@@ -248,7 +255,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = AdminGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -259,7 +269,10 @@ class TestGenerator(TestCase):
         assert ("@admin.register(Article)" in body) is True
         # test when model already registered
         generator_obj = AdminGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -273,7 +286,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Article", ("title:charfield",))
+        generator_obj = Generator("blog", "Article", ("title:charfield",), True)
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         head, body = generator_obj.get_viewset_parts()
@@ -285,7 +298,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = ViewGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=True,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -297,7 +313,10 @@ class TestGenerator(TestCase):
         assert ("ArticleSerializer" in body) is True
         # test if view already exists
         generator_obj = ViewGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=True,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -314,7 +333,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = SerializerGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -327,7 +349,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = SerializerGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=True,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -340,7 +365,10 @@ class TestGenerator(TestCase):
         assert ("ArticleSerializer" in body) is True
         # test if serializer already exists
         generator_obj = SerializerGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -357,7 +385,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = URLGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -371,7 +402,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = URLGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -382,7 +416,10 @@ class TestGenerator(TestCase):
         assert (", ArticleViewSet)" in body) is True
         # test : if url have been added we won't add it again
         generator_obj = URLGenerator(
-            app_name="blog", model_name="Article", fields=("title:charfield",)
+            app_name="blog",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -393,7 +430,10 @@ class TestGenerator(TestCase):
         assert body.count(", ArticleViewSet)") == 1
         # test : if when creating another resource we replace the url_patterns
         generator_obj = URLGenerator(
-            app_name="blog", model_name="Author", fields=("name:charfield",)
+            app_name="blog",
+            model_name="Author",
+            fields=("name:charfield",),
+            is_full=False,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -405,7 +445,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Article", ("title:charfield",))
+        generator_obj = Generator("blog", "Article", ("title:charfield",), False)
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         generator_obj.run()
@@ -416,7 +456,10 @@ class TestGenerator(TestCase):
         Tests
         """
         generator_obj = AppGenerator(
-            app_name="blog2", model_name="Article", fields=("title:charfield",)
+            app_name="blog2",
+            model_name="Article",
+            fields=("title:charfield",),
+            is_full=True,
         )
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
@@ -436,7 +479,7 @@ class TestGenerator(TestCase):
         """
         Tests
         """
-        generator_obj = Generator("blog", "Author", ("name:charfield",))
+        generator_obj = Generator("blog", "Author", ("name:charfield",), True)
         generator_obj.core_dir = self.core_folder
         generator_obj.api_dir = self.api_folder
         generator_obj.generate()
@@ -448,7 +491,7 @@ class TestGenerator(TestCase):
         """
         delattr(self.test_settings, "CORE_FOLDER")
         delattr(self.test_settings, "API_FOLDER")
-        generator = Generator("blog", "Author", ("name:charfield",))
+        generator = Generator("blog", "Author", ("name:charfield",), False)
         assert generator.core_dir == ""
         assert generator.api_dir == ""
 
@@ -460,7 +503,7 @@ class TestGenerator(TestCase):
         setattr(self.test_settings, "CORE_FOLDER", "core")
         setattr(self.test_settings, "API_FOLDER", "api")
         with pytest.raises(ValueError, match=r".* should end with .*"):
-            Generator("blog", "Author", ("name:charfield",))
+            Generator("blog", "Author", ("name:charfield",), False)
         # settings to normal
         setattr(self.test_settings, "CORE_FOLDER", "my_app_core/")
         setattr(self.test_settings, "API_FOLDER", "my_app_api/")
@@ -471,6 +514,6 @@ class TestGenerator(TestCase):
         """
         setattr(self.test_settings, "CORE_FOLDER", "core/")
         setattr(self.test_settings, "API_FOLDER", "api/")
-        generator_obj = Generator("blog", "Author", ("name:charfield",))
+        generator_obj = Generator("blog", "Author", ("name:charfield",), False)
         assert generator_obj.core_dir == "core/"
         assert generator_obj.api_dir == "api/"


### PR DESCRIPTION
1. old way is still supported when we don't pass the option --mixins
2. when passing a for example: --mixins CR will generate a view with only the create, list and  retrieve actions all other endpoints will have access restricted